### PR TITLE
Open scss and less files as their own languages

### DIFF
--- a/app/assets/javascripts/mbeditor/components/DiffViewer.js
+++ b/app/assets/javascripts/mbeditor/components/DiffViewer.js
@@ -110,7 +110,7 @@ var DiffViewer = function DiffViewer(_ref) {
       'js': 'javascript', 'jsx': 'javascript',
       'ts': 'typescript', 'tsx': 'typescript',
       'json': 'json', 'yml': 'yaml', 'yaml': 'yaml',
-      'css': 'css', 'scss': 'scss', 'sass': 'css',
+      'css': 'css', 'scss': 'scss', 'less': 'less', 'sass': 'css',
       'html': 'html', 'erb': 'erb', 'haml': 'haml',
       'xml': 'xml', 'md': 'markdown', 'markdown': 'markdown',
       'sh': 'shell', 'bash': 'shell', 'zsh': 'shell'

--- a/app/assets/javascripts/mbeditor/components/DiffViewer.js
+++ b/app/assets/javascripts/mbeditor/components/DiffViewer.js
@@ -110,7 +110,7 @@ var DiffViewer = function DiffViewer(_ref) {
       'js': 'javascript', 'jsx': 'javascript',
       'ts': 'typescript', 'tsx': 'typescript',
       'json': 'json', 'yml': 'yaml', 'yaml': 'yaml',
-      'css': 'css', 'scss': 'css', 'sass': 'css',
+      'css': 'css', 'scss': 'scss', 'sass': 'css',
       'html': 'html', 'erb': 'erb', 'haml': 'haml',
       'xml': 'xml', 'md': 'markdown', 'markdown': 'markdown',
       'sh': 'shell', 'bash': 'shell', 'zsh': 'shell'

--- a/app/assets/javascripts/mbeditor/components/EditorPanel.js
+++ b/app/assets/javascripts/mbeditor/components/EditorPanel.js
@@ -496,6 +496,8 @@ var EditorPanel = function EditorPanel(_ref) {
       language = 'css';
     } else if (/\.scss\.erb$/.test(fileNameLower)) {
       language = 'scss';
+    } else if (/\.less\.erb$/.test(fileNameLower)) {
+      language = 'less';
     } else if (/\.html\.erb$/.test(fileNameLower)) {
       language = 'erb';
     } else if (/\.html\.haml$/.test(fileNameLower)) {
@@ -521,14 +523,16 @@ var EditorPanel = function EditorPanel(_ref) {
         language = 'javascript';break;
       case 'ts':case 'tsx':
         language = 'typescript';break;
-      // scss is its own Monaco language. Sent to 'css' it got no highlighting
-      // at all and the CSS validator flagged every $variable, @use, & nesting
-      // and @mixin. '.sass' stays on css: the indented syntax has no Monaco
-      // language, and scss's validator would reject it just as loudly.
+      // scss and less are their own Monaco languages, and reach nothing useful
+      // without these: scss went to css and got flagged line by line, less went
+      // nowhere and fell through to plaintext. '.sass' stays on css because
+      // Monaco has no sass language, and scss would reject it just as loudly.
       case 'css':case 'sass':
         language = 'css';break;
       case 'scss':
         language = 'scss';break;
+      case 'less':
+        language = 'less';break;
       case 'html':
         language = 'html';break;
       case 'erb':

--- a/app/assets/javascripts/mbeditor/components/EditorPanel.js
+++ b/app/assets/javascripts/mbeditor/components/EditorPanel.js
@@ -494,6 +494,8 @@ var EditorPanel = function EditorPanel(_ref) {
       language = 'javascript';
     } else if (/\.css\.erb$/.test(fileNameLower)) {
       language = 'css';
+    } else if (/\.scss\.erb$/.test(fileNameLower)) {
+      language = 'scss';
     } else if (/\.html\.erb$/.test(fileNameLower)) {
       language = 'erb';
     } else if (/\.html\.haml$/.test(fileNameLower)) {
@@ -519,8 +521,14 @@ var EditorPanel = function EditorPanel(_ref) {
         language = 'javascript';break;
       case 'ts':case 'tsx':
         language = 'typescript';break;
-      case 'css':case 'scss':case 'sass':
+      // scss is its own Monaco language. Sent to 'css' it got no highlighting
+      // at all and the CSS validator flagged every $variable, @use, & nesting
+      // and @mixin. '.sass' stays on css: the indented syntax has no Monaco
+      // language, and scss's validator would reject it just as loudly.
+      case 'css':case 'sass':
         language = 'css';break;
+      case 'scss':
+        language = 'scss';break;
       case 'html':
         language = 'html';break;
       case 'erb':

--- a/test/lib/mbeditor/stylesheet_language_contract_test.rb
+++ b/test/lib/mbeditor/stylesheet_language_contract_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Mbeditor
+  # scss shipped mapped to Monaco's 'css' language in two places while
+  # PRETTIER_PARSERS already said 'scss'. The CSS validator then flagged every
+  # $variable, @use, & nesting and @mixin, and the css tokenizer produced no
+  # highlighting at all, so an scss file opened as an unreadable wall of red.
+  #
+  # A source guard, not a behavioural one: the language is chosen inside
+  # EditorPanel's render and is only observable through a Monaco stub. It
+  # catches what actually went wrong, which is these copies drifting apart.
+  class StylesheetLanguageContractTest < ActiveSupport::TestCase
+    SOURCES = %w[
+      app/assets/javascripts/mbeditor/components/EditorPanel.js
+      app/assets/javascripts/mbeditor/components/DiffViewer.js
+    ].freeze
+
+    def source(relative)
+      File.read(Mbeditor::Engine.root.join(relative))
+    end
+
+    test "no stylesheet language map sends scss to css" do
+      SOURCES.each do |relative|
+        body = source(relative)
+
+        refute_match(/'scss':\s*'css'/, body, "#{relative} maps scss to css")
+        refute_match(/case 'css':case 'scss'/, body, "#{relative} lumps scss in with css")
+        assert_match(/'scss'/, body, "#{relative} no longer mentions scss at all")
+      end
+    end
+
+    test "scss.erb is treated as scss, the way css.erb is treated as css" do
+      assert_match(/\\.scss\\.erb\$/, source(SOURCES.first))
+    end
+  end
+end

--- a/test/lib/mbeditor/stylesheet_language_contract_test.rb
+++ b/test/lib/mbeditor/stylesheet_language_contract_test.rb
@@ -3,10 +3,11 @@
 require "test_helper"
 
 module Mbeditor
-  # scss shipped mapped to Monaco's 'css' language in two places while
-  # PRETTIER_PARSERS already said 'scss'. The CSS validator then flagged every
-  # $variable, @use, & nesting and @mixin, and the css tokenizer produced no
-  # highlighting at all, so an scss file opened as an unreadable wall of red.
+  # scss shipped mapped to Monaco's 'css' language in two places, and less was
+  # mapped in neither, while PRETTIER_PARSERS already named both. The CSS
+  # validator flagged every $variable, @use, & nesting and @mixin and produced
+  # no highlighting, so scss opened as an unreadable wall of red; less fell
+  # through to plaintext and got no highlighting or language service at all.
   #
   # A source guard, not a behavioural one: the language is chosen inside
   # EditorPanel's render and is only observable through a Monaco stub. It
@@ -21,18 +22,22 @@ module Mbeditor
       File.read(Mbeditor::Engine.root.join(relative))
     end
 
-    test "no stylesheet language map sends scss to css" do
-      SOURCES.each do |relative|
-        body = source(relative)
+    # Monaco registers css, scss and less. Each must reach its own language:
+    # scss was being sent to css, less was reaching nothing.
+    %w[scss less].each do |lang|
+      test "no stylesheet language map sends #{lang} somewhere else" do
+        SOURCES.each do |relative|
+          body = source(relative)
 
-        refute_match(/'scss':\s*'css'/, body, "#{relative} maps scss to css")
-        refute_match(/case 'css':case 'scss'/, body, "#{relative} lumps scss in with css")
-        assert_match(/'scss'/, body, "#{relative} no longer mentions scss at all")
+          refute_match(/'#{lang}':\s*'css'/, body, "#{relative} maps #{lang} to css")
+          refute_match(/case 'css':case '#{lang}'/, body, "#{relative} lumps #{lang} in with css")
+          assert_match(/'#{lang}'/, body, "#{relative} does not map #{lang} at all")
+        end
       end
-    end
 
-    test "scss.erb is treated as scss, the way css.erb is treated as css" do
-      assert_match(/\\.scss\\.erb\$/, source(SOURCES.first))
+      test "#{lang}.erb is treated as #{lang}, the way css.erb is treated as css" do
+        assert_match(/\\.#{lang}\\.erb\$/, source(SOURCES.first))
+      end
     end
   end
 end

--- a/test/system/mbeditor/js_globals_system_test.rb
+++ b/test/system/mbeditor/js_globals_system_test.rb
@@ -170,10 +170,16 @@ module Mbeditor
               .map(function (m) { return { severity: m.severity, code: String(m.code && m.code.value || m.code || ''), message: m.message }; });
           })()
         JS
+        # Wait for the graded severities, not merely for the markers to exist.
+        # TypeScript emits all three as Error and patchSeverities downgrades two
+        # of them a beat later, so a gate that matches on presence alone can
+        # break out on the unpatched set and fail the assertions below against
+        # a severity that was about to change. Same race the globals test above
+        # documents, and it is why that one waits on settled text.
         break if markers.is_a?(Array) &&
-                 markers.any? { |m| m["code"] == "2554" } &&
-                 markers.any? { |m| m["message"].include?("bogusPropXyz") } &&
-                 markers.any? { |m| m["message"].include?("is missing in type") }
+                 markers.any? { |m| m["code"] == "2554" && m["severity"] == 4 } &&
+                 markers.any? { |m| m["message"].include?("bogusPropXyz") && m["severity"] == 4 } &&
+                 markers.any? { |m| m["message"].include?("is missing in type") && m["severity"] == 8 }
 
         flunk "call-shape markers never settled; last: #{markers.inspect}" if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
         sleep 0.5


### PR DESCRIPTION
Two bugs in the same place: mbeditor never reached Monaco's `scss` or `less` languages.

## scss — opened as `css`

The CSS language service validated it as plain CSS, so every `$variable`, `@use`, `&` nesting and `@mixin` came back an error, and the CSS tokenizer produced nothing usable, so there was no highlighting either.

## less — opened as `plaintext`

Mapped in neither `EditorPanel.js` nor `DiffViewer.js`, so it fell straight through to plaintext. Quieter than the scss bug — no red squiggles — and correspondingly easier to miss.

| file | language before | errors | token types |
|---|---|---|---|
| `.scss` | `css` | 8 | 1 (empty) |
| `.scss` | **`scss`** | **0** | **12** (`variable.decl.scss`, `variable.ref.scss`, …) |
| `.less` | `plaintext` | 0 | 1 (empty) |
| `.less` | **`less`** | **0** | **12** (`variable.less`, `tag.class.less`, …) |

## Why both were wrong

The extension→language mapping is duplicated, and the copies drifted. `PRETTIER_PARSERS` in `MbeditorApp.js` already named both `scss` and `less`; `EditorPanel.js` and `DiffViewer.js` did not. So the editor **formatted** these files correctly and **highlighted** them incorrectly — the same pathology `PRETTIER_PARSERS`' own comment records from a previous round.

Several features were keyed on these languages and therefore unreachable, since nothing ever set them: `EMMET_STYLE_LANGS` (`css/scss/less`), the color provider's skip list, and `PRETTIER_LANGUAGE_PARSERS` for format-on-paste.

## Scope decisions

- **`.scss.erb` and `.less.erb`** resolve to `scss`/`less`, completing the compound branch alongside the existing `.css.erb`. ERB tags draw a marker under any of the three (2 for `.css.erb`, 1 each here), which is the tradeoff `.css.erb` already makes.
- **`.sass` deliberately stays on `css`.** Monaco registers only `css`, `scss` and `less` — there is no `sass` language — and the indented syntax would be rejected by the scss validator just as loudly.

## Verification

`bundle exec rake test` — 1142 runs, 3642 assertions, 0 failures, 0 errors, 3 skips.

Driven in a real browser against the dummy app, each fixture opened through the editor's own path:

| file | language | markers |
|---|---|---|
| `plain.css` | `css` | 0 (no regression) |
| `probe.scss` | `scss` | 0 (was 8) |
| `probe.less` | `less` | 0 (was plaintext) |
| `templated.scss.erb` | `scss` | 1, on the ERB tag |
| `templated.less.erb` | `less` | 1, on the ERB tag |

`stylesheet_language_contract_test.rb` loops the family rather than naming a language, so a third stylesheet language costs one word. Checked against both pre-fix states: **2 of 2 failures** before the scss commit, **2 of 4** before the less commit, 0 after. It is a source guard rather than a behavioural one — the language is chosen inside `EditorPanel`'s render and is only observable through a Monaco stub — and it targets the actual failure mode, which is these copies drifting apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)